### PR TITLE
Fix: Update axis labels in plotting.py to millimeters

### DIFF
--- a/code/plotting.py
+++ b/code/plotting.py
@@ -29,8 +29,8 @@ def main():
     plt.scatter(x_c, y_c,   s=50, color='red', marker='o', label='Detected corners')
 
     # Labels & legend
-    plt.xlabel('X [m]')
-    plt.ylabel('Y [m]')
+    plt.xlabel('X [mm]')
+    plt.ylabel('Y [mm]')
     plt.title('LiDAR Scan with Detected Corners')
     plt.axis('equal')
     plt.legend(loc='upper right')


### PR DESCRIPTION
The plotting.py script's x and y axis labels were changed from '[m]' to '[mm]'. This change ensures the plot labels accurately reflect the units of the coordinate data in `lidarDataCartesian.csv` and `outputCorners.csv`, which are generated by the C program using millimeter units consistent with the project's configuration values.